### PR TITLE
chore: release workspace 2.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
-  ".": "2.0.0",
+  ".": "2.0.1",
   "packages/shared": "2.0.0",
-  "desktop": "2.0.0",
+  "desktop": "2.0.1",
   "packages/electron-ipcx": "2.0.0",
   "packages/autoglm.js": "2.0.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.0...workspace-v2.0.1) (2026-01-06)
+
+
+### Bug Fixes
+
+* 🐛 Fix the problem of abnormal subscription recharge fee ([b32043c](https://github.com/viarotel-org/escrcpy/commit/b32043c5f2a37792d8c336f09f4b62534ce43bec))
+
 ## [2.0.0](https://github.com/viarotel-org/escrcpy/compare/workspace-v1.34.2...workspace-v2.0.0) (2026-01-05)
 
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.0...desktop-v2.0.1) (2026-01-06)
+
+
+### Bug Fixes
+
+* 🐛 Fix the problem of abnormal subscription recharge fee ([b32043c](https://github.com/viarotel-org/escrcpy/commit/b32043c5f2a37792d8c336f09f4b62534ce43bec))
+
 ## [2.0.0](https://github.com/viarotel-org/escrcpy/compare/desktop-v1.34.2...desktop-v2.0.0) (2026-01-05)
 
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@escrcpy/desktop",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
   "description": "Scrcpy Powered by Electron",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@escrcpy/workspace",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
   "description": "Scrcpy Powered by Electron",

--- a/packages/autoglm.js/package.json
+++ b/packages/autoglm.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autoglm.js",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "packageManager": "pnpm@10.25.0",
   "description": "AutoGLM.js is a JavaScript library for Open-AutoGLM",

--- a/packages/electron-ipcx/package.json
+++ b/packages/electron-ipcx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@escrcpy/electron-ipcx",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "A more intuitive electron ipc system with function proxy support",
   "author": "viarotel",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autoglm.js/shared",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "packageManager": "pnpm@10.25.0",
   "description": "Shared utilities for autoglm.js",


### PR DESCRIPTION
🚀 Release Please
---


<details><summary>desktop: 2.0.1</summary>

## [2.0.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.0...desktop-v2.0.1) (2026-01-06)


### Bug Fixes

* 🐛 Fix the problem of abnormal subscription recharge fee ([b32043c](https://github.com/viarotel-org/escrcpy/commit/b32043c5f2a37792d8c336f09f4b62534ce43bec))
</details>

<details><summary>workspace: 2.0.1</summary>

## [2.0.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.0...workspace-v2.0.1) (2026-01-06)


### Bug Fixes

* 🐛 Fix the problem of abnormal subscription recharge fee ([b32043c](https://github.com/viarotel-org/escrcpy/commit/b32043c5f2a37792d8c336f09f4b62534ce43bec))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).