### PR TITLE
chore: release 2.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   ".": "2.1.0",
-  "desktop": "2.1.0",
-  "packages/electron-ipcx": "2.0.1"
+  "desktop": "2.1.1",
+  "packages/electron-ipcx": "2.0.2"
 }

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.1.0...desktop-v2.1.1) (2026-01-14)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @escrcpy/electron-ipcx bumped to 2.0.2
+
 ## [2.1.0](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.1...desktop-v2.1.0) (2026-01-14)
 
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "escrcpy",
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
   "description": "Scrcpy Powered by Electron",

--- a/packages/electron-ipcx/CHANGELOG.md
+++ b/packages/electron-ipcx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.2](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.1...electron-ipcx-v2.0.2) (2026-01-14)
+
+
+### Bug Fixes
+
+* **types:** allow typed payload handlers by using any[] for handle listener rest params ([b4e8058](https://github.com/viarotel-org/escrcpy/commit/b4e8058de275e42e2645095c70a3b5d6a5e64c07))
+
 ## [2.0.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.0...electron-ipcx-v2.0.1) (2026-01-14)
 
 

--- a/packages/electron-ipcx/package.json
+++ b/packages/electron-ipcx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@escrcpy/electron-ipcx",
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "private": false,
   "description": "A more intuitive electron ipc system with function proxy support",
   "author": "viarotel",


### PR DESCRIPTION
🚀 Release Please
---


<details><summary>electron-ipcx: 2.0.2</summary>

## [2.0.2](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.0.1...electron-ipcx-v2.0.2) (2026-01-14)


### Bug Fixes

* **types:** allow typed payload handlers by using any[] for handle listener rest params ([b4e8058](https://github.com/viarotel-org/escrcpy/commit/b4e8058de275e42e2645095c70a3b5d6a5e64c07))
</details>

<details><summary>desktop: 2.1.1</summary>

## [2.1.1](https://github.com/viarotel-org/escrcpy/compare/workspace-v2.1.0...desktop-v2.1.1) (2026-01-14)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @escrcpy/electron-ipcx bumped to 2.0.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).