### PR TITLE
Enable flex display for virtual displays

### DIFF
--- a/desktop/electron/middleware/scrcpy/index.js
+++ b/desktop/electron/middleware/scrcpy/index.js
@@ -100,6 +100,10 @@ async function launch(serial, args = {}) {
       ? ` --new-display=${newDisplay}`
       : ` --new-display`
 
+    if (!/\s(?:--flex-display|-x)(?:\s|$)/.test(commands)) {
+      commands += ` --flex-display`
+    }
+
     if (!newDisplay) {
       const displayOverlay = getDisplayOverlay(serial)
 


### PR DESCRIPTION
This updates virtual-display launches to include scrcpy's flex display option, so new display windows can resize continuously with the desktop window while preserving existing custom flex-display arguments when users already provide them.